### PR TITLE
Potential fix for code scanning alert no. 24: CORS misconfiguration for credentials transfer

### DIFF
--- a/src/context/SharedContextServer.ts
+++ b/src/context/SharedContextServer.ts
@@ -168,17 +168,24 @@ export class SharedContextServer extends EventEmitter {
         'http://127.0.0.1:3000',
         'http://127.0.0.1:3001',
         'http://127.0.0.1:3002',
-        'http://127.0.0.1:3003',
-        'file://'  // For local development tools
+        'http://127.0.0.1:3003'
+        // Removed 'file://' for security, do not allow it for credentialed CORS
       ];
       
-      if (allowedOrigins.includes(origin)) {
+      // Never allow "null" or "file://" as credentialed CORS origin
+      if (allowedOrigins.includes(origin) && origin !== "null" && origin !== "file://") {
         res.setHeader('Access-Control-Allow-Origin', origin);
         res.setHeader('Access-Control-Allow-Credentials', 'true');
-      } else if (origin.startsWith('http://localhost:') || origin.startsWith('http://127.0.0.1:')) {
-        // Allow any localhost port for development flexibility
+      } else if ((origin && (origin.startsWith('http://localhost:') || origin.startsWith('http://127.0.0.1:')))
+        && origin !== "null" && origin !== "file://") {
+        // Allow development flexibility but never send credential header
         res.setHeader('Access-Control-Allow-Origin', origin);
-        // Don't allow credentials for dynamic origins
+        res.setHeader('Access-Control-Allow-Credentials', 'false');
+      } else {
+        // For all other cases, do not reflect origin nor allow credentials
+        // Optionally, you could omit CORS headers entirely,
+        // or respond with a safe default:
+        res.setHeader('Access-Control-Allow-Origin', 'false');
         res.setHeader('Access-Control-Allow-Credentials', 'false');
       }
       


### PR DESCRIPTION
Potential fix for [https://github.com/VibeCodingWithPhil/agentwise/security/code-scanning/24](https://github.com/VibeCodingWithPhil/agentwise/security/code-scanning/24)

To fix the vulnerability, ensure that origins provided by the client (`req.headers.origin`) are never blindly reflected.  
- Only allow credentialed requests from origins that are strictly whitelisted in a static, validated manner, and never reflect dynamic or user-controlled origins.
- If origin matches the exact value in a static whitelist and is not `"null"` (which is always unsafe in credentialed CORS scenarios), then set `Access-Control-Allow-Origin` to that origin and allow credentials.
- For non-whitelisted origins (including any dynamic localhost variants), set `Access-Control-Allow-Origin` to a safe default (possibly don't set the header, or set to `"false"` or omit the header entirely), and set `Access-Control-Allow-Credentials` to `'false'`.
- Remove `"file://"` from allowed origins if credentials will ever be used.
- Never ever reflect the `"null"` origin, even if an attacker tries to trick your logic.

Specifically, in `handleHttpRequest` inside src/context/SharedContextServer.ts, ensure that:
- `"null"` is never in the whitelist.
- `"file://"` is never in the whitelist.
- Only reflect origins exactly matching a static whitelist.
- For any other or dynamic origins, do not reflect nor allow credentials.
- If you wish to allow local development flexibility, consider a secondary implementation that never sends credential headers for those variants.
- Thus, edit lines 162–182 so that credentials are only ever allowed for strictly whitelisted, safe origins.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
